### PR TITLE
feat: add support for comments in test results via `Qase::comment`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ parameterize your tests.
 
 For example:
 
-```injectablephp
+```php
 <?php
 
 namespace Tests;
@@ -44,6 +44,7 @@ use Qase\PHPUnitReporter\Attributes\Parameter;
 use Qase\PHPUnitReporter\Attributes\QaseId;
 use Qase\PHPUnitReporter\Attributes\Suite;
 use Qase\PHPUnitReporter\Attributes\Title;
+use Qase\PHPUnitReporter\Qase;
 
 #[Suite("Main suite")]
 class SimplesTest extends TestCase
@@ -54,6 +55,7 @@ class SimplesTest extends TestCase
     ]
     public function testOne(): void
     {
+        Qase::comment("My comment");
         $this->assertTrue(true);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.0.2",
+  "version": "2.0.3",
   "scripts": {
     "test": "phpunit"
   },

--- a/src/Qase.php
+++ b/src/Qase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PHPUnitReporter;
+
+class Qase
+{
+    /*
+     * Add comment to test case
+     * @param string $message
+     * @return void
+     *
+     * Example:
+     * Qase::comment("My comment");
+     */
+    public static function comment(string $message): void
+    {
+        $qr = QaseReporter::getInstanceWithoutInit();
+        if (!$qr) {
+            return;
+        }
+
+        $qr->addComment($message);
+    }
+}

--- a/src/QaseExtension.php
+++ b/src/QaseExtension.php
@@ -22,7 +22,7 @@ final class QaseExtension implements Extension
         $attributeReader = new AttributeReader();
         $attributeParser = new AttributeParser($logger, $attributeReader);
 
-        $reporter = new QaseReporter($attributeParser, $coreReporter);
+        $reporter = QaseReporter::getInstance($attributeParser, $coreReporter);
         
         $facade->registerSubscribers(
             new Events\TestConsideredRiskySubscriber($reporter),


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and documentation of the Qase PHPUnit Reporter. The key changes involve adding a new `Qase` class for comments, updating the singleton pattern in the `QaseReporter` class, and making minor documentation and version updates.

### New functionality:

* [`src/Qase.php`](diffhunk://#diff-0c4e10ed9305b4483508d05c55d1d22fe88a257a971f796f4baa0ebdc568bc02R1-R26): Added a new `Qase` class with a static `comment` method to add comments to test cases.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58): Updated documentation to include usage of the new `Qase::comment` method.

### Code improvements:

* [`src/QaseReporter.php`](diffhunk://#diff-87b3c7cfd737b7dfeb8d750b1e4700713af506f4df9111a92b64f4dc24fba141R14-R38): Implemented the singleton pattern for the `QaseReporter` class by adding `getInstance` and `getInstanceWithoutInit` methods.
* [`src/QaseReporter.php`](diffhunk://#diff-87b3c7cfd737b7dfeb8d750b1e4700713af506f4df9111a92b64f4dc24fba141R52): Added a `currentKey` property and an `addComment` method to support the new comment functionality. [[1]](diffhunk://#diff-87b3c7cfd737b7dfeb8d750b1e4700713af506f4df9111a92b64f4dc24fba141R52) [[2]](diffhunk://#diff-87b3c7cfd737b7dfeb8d750b1e4700713af506f4df9111a92b64f4dc24fba141R117-R125)

### Documentation and version updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35): Corrected the code block language from `injectablephp` to `php`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47): Added the `use Qase\PHPUnitReporter\Qase` import statement.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L37-R37): Updated the version from `2.0.2` to `2.0.3`.