### PR TITLE
feat: add `Qase::attach` function for attaching files to test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ class SimplesTest extends TestCase
     ]
     public function testTwo(): void
     {
+        Qase::attach("/my_path/file.json");
         $this->assertTrue(false);
     }
 
@@ -75,6 +76,7 @@ class SimplesTest extends TestCase
     ]
     public function testThree(): void
     {
+        Qase::attach((object) ['title' => 'attachment.txt', 'content' => 'Some string', 'mime' => 'text/plain']);
         throw new Exception('Some exception');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^8.1",
     "phpunit/phpunit": "^10 || ^11",
-    "qase/php-commons": "^2.0.1"
+    "qase/php-commons": "^2.0.4"
   },
   "autoload": {
     "psr-4": {
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.0.3",
+  "version": "2.0.4",
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a147aeac95742939d62cc878dbdb4b1",
+    "content-hash": "3c61bd37fe6298d9a38348f6efc05971",
     "packages": [
         {
             "name": "brick/math",
@@ -950,16 +950,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.44",
+            "version": "10.5.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1381c62769be4bb88fa4c5aec1366c7c66ca4f36"
+                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1381c62769be4bb88fa4c5aec1366c7c66ca4f36",
-                "reference": "1381c62769be4bb88fa4c5aec1366c7c66ca4f36",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bd68a781d8e30348bc297449f5234b3458267ae8",
+                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8",
                 "shasum": ""
             },
             "require": {
@@ -1031,7 +1031,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.44"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.45"
             },
             "funding": [
                 {
@@ -1047,7 +1047,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-31T07:00:38+00:00"
+            "time": "2025-02-06T16:08:12+00:00"
         },
         {
             "name": "psr/http-client",
@@ -1211,16 +1211,16 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "e521dafafa348ddd1d94158d9672a2f10f7bacad"
+                "reference": "08e98891ac95a1c4403fb757aec2d8e5cae3f105"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/e521dafafa348ddd1d94158d9672a2f10f7bacad",
-                "reference": "e521dafafa348ddd1d94158d9672a2f10f7bacad",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/08e98891ac95a1c4403fb757aec2d8e5cae3f105",
+                "reference": "08e98891ac95a1c4403fb757aec2d8e5cae3f105",
                 "shasum": ""
             },
             "require": {
@@ -1260,9 +1260,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.0.1"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.0.4"
             },
-            "time": "2025-02-06T11:59:37+00:00"
+            "time": "2025-02-11T15:20:21+00:00"
         },
         {
             "name": "qase/qase-api-client",
@@ -1322,16 +1322,16 @@
         },
         {
             "name": "qase/qase-api-v2-client",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-v2-client.git",
-                "reference": "8c611cae0c9e882400b0f97fdddef23c8423d856"
+                "reference": "ba1d24d8261750d37687d461c0d6823f1a0b8314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/8c611cae0c9e882400b0f97fdddef23c8423d856",
-                "reference": "8c611cae0c9e882400b0f97fdddef23c8423d856",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/ba1d24d8261750d37687d461c0d6823f1a0b8314",
+                "reference": "ba1d24d8261750d37687d461c0d6823f1a0b8314",
                 "shasum": ""
             },
             "require": {
@@ -1372,9 +1372,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-v2-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.0.0"
+                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.0.1"
             },
-            "time": "2025-01-30T16:57:01+00:00"
+            "time": "2025-02-10T14:26:14+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Qase.php
+++ b/src/Qase.php
@@ -23,4 +23,23 @@ class Qase
 
         $qr->addComment($message);
     }
+
+    /* Add attachment to test case
+     * @param mixed $input
+     * @return void
+     *
+     * Example:
+     * Qase::attach("/my_path/file.json");
+     * Qase::attach(["/my_path/file.json", "/my_path/file2.json"]);
+     * Qase::attach((object) ['title' => 'attachment.txt', 'content' => 'Some string', 'mime' => 'text/plain']);
+     */
+    public static function attach(mixed $input): void
+    {
+        $qr = QaseReporter::getInstanceWithoutInit();
+        if (!$qr) {
+            return;
+        }
+
+        $qr->addAttachment($input);
+    }
 }

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -6,6 +6,7 @@ namespace Qase\PHPUnitReporter;
 
 use PHPUnit\Event\Code\TestMethod;
 use Qase\PhpCommons\Interfaces\ReporterInterface;
+use Qase\PhpCommons\Models\Attachment;
 use Qase\PhpCommons\Models\Result;
 use Qase\PHPUnitReporter\Attributes\AttributeParserInterface;
 
@@ -122,5 +123,36 @@ class QaseReporter implements QaseReporterInterface
         }
 
         $this->testResults[$this->currentKey]->message = $this->testResults[$this->currentKey]->message . $message . "\n";
+    }
+
+    public function addAttachment(mixed $input): void
+    {
+        if (!$this->currentKey) {
+            return;
+        }
+
+        if (is_string($input)) {
+            $this->testResults[$this->currentKey]->attachments[] = Attachment::createFileAttachment($input);
+            return;
+        }
+
+        if (is_array($input)) {
+            foreach ($input as $item) {
+                if (is_string($item)) {
+                    $this->testResults[$this->currentKey]->attachments[] = Attachment::createFileAttachment($item);
+                }
+            }
+
+            return;
+        }
+
+        if (is_object($input)) {
+            $data = (array)$input;
+            $this->testResults[$this->currentKey]->attachments[] = Attachment::createContentAttachment(
+                $data['title'] ?? 'attachment',
+                $data['content'] ?? null,
+                $data['mime'] ?? null
+            );
+        }
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `Qase` library, focusing on adding support for attaching files and content to test cases, as well as updating dependencies. The most important changes are summarized below:

### New Features:

* Added `Qase::attach` method to support attaching files and content to test cases. This method can handle strings, arrays, and objects as inputs. (`src/Qase.php`)

* Implemented `addAttachment` method in `QaseReporter` to manage attachments for the current test case. This method supports different input types and creates appropriate attachment objects. (`src/QaseReporter.php`)

### Dependency Updates:

* Updated `qase/php-commons` dependency from version `^2.0.1` to `^2.0.4` in `composer.json`. (`composer.json`)

* Updated the package version from `2.0.3` to `2.0.4` in `composer.json`. (`composer.json`)

### Test Cases:

* Added calls to `Qase::attach` in `SimplesTest` to demonstrate attaching a file and an object with content. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79)