### PR TITLE
feat: enhance Qase ID handling and update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^8.1",
     "phpunit/phpunit": "^10 || ^11",
-    "qase/php-commons": "^2.0.6"
+    "qase/php-commons": "^2.1.0"
   },
   "autoload": {
     "psr-4": {
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.0.5",
+  "version": "2.1.0",
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9263c014209f3577a1d774e4e151f2ec",
+    "content-hash": "1d421abb05ffcd2aadc93c4865c1585a",
     "packages": [
         {
             "name": "brick/math",
@@ -68,16 +68,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.2",
+            "version": "7.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b"
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d281ed313b989f213357e3be1a179f02196ac99b",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
                 "shasum": ""
             },
             "require": {
@@ -174,7 +174,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
             },
             "funding": [
                 {
@@ -190,20 +190,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-24T11:22:20+00:00"
+            "time": "2025-03-27T13:37:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.4",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455"
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
                 "shasum": ""
             },
             "require": {
@@ -257,7 +257,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.4"
+                "source": "https://github.com/guzzle/promises/tree/2.2.0"
             },
             "funding": [
                 {
@@ -273,20 +273,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-17T10:06:22+00:00"
+            "time": "2025-03-27T13:27:01+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
                 "shasum": ""
             },
             "require": {
@@ -373,7 +373,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
             },
             "funding": [
                 {
@@ -389,7 +389,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T11:15:46+00:00"
+            "time": "2025-03-27T12:30:47+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1211,22 +1211,22 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.0.6",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "5a5fd1cead865e102f45f51787192631a5d1a574"
+                "reference": "7d471c7147f71f11765e64e3749b7a1c7527102b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/5a5fd1cead865e102f45f51787192631a5d1a574",
-                "reference": "5a5fd1cead865e102f45f51787192631a5d1a574",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/7d471c7147f71f11765e64e3749b7a1c7527102b",
+                "reference": "7d471c7147f71f11765e64e3749b7a1c7527102b",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.0",
-                "qase/qase-api-client": "^1.0.0",
-                "qase/qase-api-v2-client": "^1.0.0",
+                "qase/qase-api-client": "^1.1.0",
+                "qase/qase-api-v2-client": "^1.1.0",
                 "ramsey/uuid": "4.7.*"
             },
             "require-dev": {
@@ -1260,22 +1260,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.0.6"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.0"
             },
-            "time": "2025-03-24T12:34:11+00:00"
+            "time": "2025-04-07T12:35:26+00:00"
         },
         {
             "name": "qase/qase-api-client",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-client.git",
-                "reference": "eaa72ef8508152e97c0d7c2cfe792b2b0113d712"
+                "reference": "672a9dcc0301a94504f521394733c2dca256c9c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/eaa72ef8508152e97c0d7c2cfe792b2b0113d712",
-                "reference": "eaa72ef8508152e97c0d7c2cfe792b2b0113d712",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/672a9dcc0301a94504f521394733c2dca256c9c1",
+                "reference": "672a9dcc0301a94504f521394733c2dca256c9c1",
                 "shasum": ""
             },
             "require": {
@@ -1316,22 +1316,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.0.1"
+                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.0"
             },
-            "time": "2025-02-12T14:54:55+00:00"
+            "time": "2025-04-07T12:28:32+00:00"
         },
         {
             "name": "qase/qase-api-v2-client",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-v2-client.git",
-                "reference": "ba1d24d8261750d37687d461c0d6823f1a0b8314"
+                "reference": "8b0c67f733c5c124cca710ec71d0f3b4d5304920"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/ba1d24d8261750d37687d461c0d6823f1a0b8314",
-                "reference": "ba1d24d8261750d37687d461c0d6823f1a0b8314",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/8b0c67f733c5c124cca710ec71d0f3b4d5304920",
+                "reference": "8b0c67f733c5c124cca710ec71d0f3b4d5304920",
                 "shasum": ""
             },
             "require": {
@@ -1372,9 +1372,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-v2-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.0.1"
+                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.0"
             },
-            "time": "2025-02-10T14:26:14+00:00"
+            "time": "2025-04-07T12:29:16+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Attributes/AttributeParser.php
+++ b/src/Attributes/AttributeParser.php
@@ -65,7 +65,11 @@ class AttributeParser implements AttributeParserInterface
             }
 
             if ($annotation instanceof QaseIdAttributeInterface) {
-                $metadata->qaseId = $annotation->getValue();
+                $metadata->qaseIds[] = $annotation->getValue();
+            }
+
+            if ($annotation instanceof QaseIdsAttributeInterface) {
+                $metadata->qaseIds = array_merge($metadata->qaseIds, $annotation->getValue());
             }
 
             if ($annotation instanceof SuiteAttributeInterface) {

--- a/src/Attributes/QaseIds.php
+++ b/src/Attributes/QaseIds.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Qase\PHPUnitReporter\Attributes;
+
+use Attribute;
+use InvalidArgumentException;
+
+/**
+ * @Annotation
+ * @Target({"METHOD"})
+ * Set Qase IDs for a test. Multiple IDs can be specified in an array.
+ * Example:
+ * #[QaseIds([1,2,3])]
+ * public function testOne(): void
+ * {
+ *    $this->assertTrue(true);
+ * }
+ * 
+ * Note: All IDs must be integers. Non-integer values will be filtered out.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class QaseIds implements QaseIdsAttributeInterface
+{
+    private array $value;
+
+    public function __construct(array $value)
+    {
+        $filtered = array_filter($value, static fn($id) => is_int($id));
+
+        if (count($filtered) !== count($value)) {
+            throw new InvalidArgumentException('QaseIds must contain only integers.');
+        }
+
+        $this->value = array_values($filtered);
+    }
+
+    public function getValue(): array
+    {
+        return $this->value;
+    }
+}

--- a/src/Attributes/QaseIdsAttributeInterface.php
+++ b/src/Attributes/QaseIdsAttributeInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Qase\PHPUnitReporter\Attributes;
+
+interface QaseIdsAttributeInterface extends AttributeInterface
+{
+    public function getValue(): array;
+}

--- a/src/Models/Metadata.php
+++ b/src/Models/Metadata.php
@@ -5,7 +5,7 @@ namespace Qase\PHPUnitReporter\Models;
 class Metadata
 {
     public ?string $title = null;
-    public ?int $qaseId = null;
+    public array $qaseIds = [];
     public array $suites = [];
     public array $parameters = [];
     public array $fields = [];

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -56,7 +56,9 @@ class QaseReporter implements QaseReporterInterface
 
         $testResult = new Result();
 
-        $testResult->testOpsId = $metadata->qaseId;
+        if (!empty($metadata->qaseIds)) {
+            $testResult->testOpsIds = $metadata->qaseIds;
+        }
 
         if (empty($metadata->suites)) {
             $suites = explode('\\', $test->className());


### PR DESCRIPTION
This pull request includes several changes to enhance the handling of Qase IDs and update dependencies. The key changes involve updating the `qase/php-commons` dependency, introducing support for multiple Qase IDs, and modifying the metadata structure to accommodate these changes.

Dependency updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L25-R25): Updated `qase/php-commons` dependency from `^2.0.6` to `^2.1.0` and version from `2.0.5` to `2.1.0`. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L25-R25) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L37-R37)

Support for multiple Qase IDs:
* [`src/Attributes/AttributeParser.php`](diffhunk://#diff-7d7f2b3c610a94c49737918fecb2ff187300223cf54c670c2073149180f65a8cL68-R72): Modified `getMetadataFromAnnotations` method to handle multiple Qase IDs by appending to `qaseIds` array and merging arrays for `QaseIdsAttributeInterface`.
* [`src/Attributes/QaseIds.php`](diffhunk://#diff-7a0ebd90dd9153570ddf51d33af9bd5aa668901c0f5db12b5491cd288f0cba0aR1-R41): Added new `QaseIds` attribute class to allow setting multiple Qase IDs for a test method.
* [`src/Attributes/QaseIdsAttributeInterface.php`](diffhunk://#diff-72c3887988f2b465cbcfa64d680f26b27730b51fa77e376641f296d6674c6a1eR1-R8): Introduced new interface `QaseIdsAttributeInterface` for handling multiple Qase IDs.
* [`src/Models/Metadata.php`](diffhunk://#diff-552ecfe8ce39e5f36e907ab61c1b798679df00a658204b464ec4d02e3c283988L8-R8): Changed `Metadata` model to replace `qaseId` with an array `qaseIds`.
* [`src/QaseReporter.php`](diffhunk://#diff-87b3c7cfd737b7dfeb8d750b1e4700713af506f4df9111a92b64f4dc24fba141L59-R61): Updated `startTest` method to use `qaseIds` array for test results.