### PR TITLE
bugfix/not-defensive-against-tests

### DIFF
--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -85,10 +85,15 @@ class QaseReporter implements QaseReporterInterface
     public function updateStatus(TestMethod $test, string $status, ?string $message = null, ?string $stackTrace = null): void
     {
         $key = $this->getTestKey($test);
+        if (!isset($this->testResults[$key])) {
+            // Optionally log or just bail out silently
+            return;
+        }
+
         $this->testResults[$key]->execution->setStatus($status);
 
         if ($message) {
-            $this->testResults[$key]->message = $this->testResults[$key]->message . "\n" . $message . "\n";
+            $this->testResults[$key]->message = ($this->testResults[$key]->message ?? '') . "\n" . $message . "\n";
         }
 
         if ($stackTrace) {
@@ -99,6 +104,10 @@ class QaseReporter implements QaseReporterInterface
     public function completeTest(TestMethod $test): void
     {
         $key = $this->getTestKey($test);
+        if (!isset($this->testResults[$key])) {
+            // Optionally log or bail
+            return;
+        }
         $this->testResults[$key]->execution->finish();
 
         $this->reporter->addResult($this->testResults[$key]);


### PR DESCRIPTION
# Fix Qase PHPUnit Reporter Crashes on Skipped/Untracked Tests
This PR makes the Qase PHPUnit Reporter integration defensive against skipped tests and untracked test lifecycle edge cases. Previously, when a test was skipped or failed to register with Qase (often with ParaTest or PHPUnit parallel runs), the reporter attempted to update or access missing test result entries. This resulted in:

`Undefined array key ... ` warnings

`Call to a member function setStatus() on null` errors

CI noise and non-zero exit codes, even though the underlying tests were fine

## What changed:

All array accesses in the QaseReporter are now protected with isset() checks.

If a test is not registered in the Qase results array (typically when skipped), the reporter gracefully ignores status updates and reporting for that test.

No impact on valid or tracked tests—only suppresses noisy errors for edge cases.

## Why:

Eliminates noisy third-party event subscriber exceptions that clutter CI and test runs.

Makes Qase reporting compatible with modern PHPUnit event lifecycles and parallel runners (ParaTest).

Ensures reliable, stable reporting without side effects from skipped or untracked tests.

## TL;DR:
Prevents Qase from crashing or throwing on skipped/unregistered tests, improving stability and reducing CI noise.

