### PR TITLE
fix: issue with skipped tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.1.1",
+  "version": "2.1.2",
   "scripts": {
     "test": "phpunit"
   },

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -85,14 +85,30 @@ class QaseReporter implements QaseReporterInterface
     public function updateStatus(TestMethod $test, string $status, ?string $message = null, ?string $stackTrace = null): void
     {
         $key = $this->getTestKey($test);
-        $this->testResults[$key]->execution->setStatus($status);
 
-        if ($message) {
-            $this->testResults[$key]->message = $this->testResults[$key]->message . "\n" . $message . "\n";
+        if (!isset($this->testResults[$key])) {
+            $this->startTest($test);
+            $this->testResults[$key]->execution->setStatus($status);
+            $this->testResults[$key]->execution->finish();
+
+            $this->handleMessage($key, $message);
+            $this->reporter->addResult($this->testResults[$key]);
+            
+            return;
         }
+
+        $this->testResults[$key]->execution->setStatus($status);
+        $this->handleMessage($key, $message);
 
         if ($stackTrace) {
             $this->testResults[$key]->execution->setStackTrace($stackTrace);
+        }
+    }
+
+    private function handleMessage(string $key, ?string $message): void
+    {
+        if ($message) {
+            $this->testResults[$key]->message = $this->testResults[$key]->message . "\n" . $message . "\n";
         }
     }
 


### PR DESCRIPTION
- Updated version number to `2.1.2` in `composer.json`.
- Refactored `updateStatus` method in `QaseReporter` to improve handling of test status updates and messages.
- Introduced a new private method `handleMessage` for better message management.