### PR TITLE
chore: bump version and update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.1.7",
+  "version": "2.1.8",
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6fab87cf96c189fea24a09a2d32131a8",
+    "content-hash": "95f95c92d5b773a060e50171eec6ccd3",
     "packages": [
         {
             "name": "brick/math",
@@ -1219,16 +1219,16 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.1.12",
+            "version": "2.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "bf177809b99c6d3bb4dc961ac5661b01919e5e54"
+                "reference": "258a7cd54949038eb3b77c9c87bc945618195610"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/bf177809b99c6d3bb4dc961ac5661b01919e5e54",
-                "reference": "bf177809b99c6d3bb4dc961ac5661b01919e5e54",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/258a7cd54949038eb3b77c9c87bc945618195610",
+                "reference": "258a7cd54949038eb3b77c9c87bc945618195610",
                 "shasum": ""
             },
             "require": {
@@ -1268,22 +1268,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.12"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.14"
             },
-            "time": "2026-01-27T13:30:32+00:00"
+            "time": "2026-02-17T07:36:59+00:00"
         },
         {
             "name": "qase/qase-api-client",
-            "version": "1.1.5",
+            "version": "1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-client.git",
-                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2"
+                "reference": "ecfaf6bebd8a42e17ce891364ea11f3eac1e830d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
-                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/ecfaf6bebd8a42e17ce891364ea11f3eac1e830d",
+                "reference": "ecfaf6bebd8a42e17ce891364ea11f3eac1e830d",
                 "shasum": ""
             },
             "require": {
@@ -1324,22 +1324,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.5"
+                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.7"
             },
-            "time": "2025-09-23T12:19:27+00:00"
+            "time": "2026-02-23T10:22:14+00:00"
         },
         {
             "name": "qase/qase-api-v2-client",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-v2-client.git",
-                "reference": "1d70ae5efc88fdb24af60bd24e3f0352237ee86c"
+                "reference": "d9581493fce8e5c86ad9821a79cea589ef6b296e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/1d70ae5efc88fdb24af60bd24e3f0352237ee86c",
-                "reference": "1d70ae5efc88fdb24af60bd24e3f0352237ee86c",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/d9581493fce8e5c86ad9821a79cea589ef6b296e",
+                "reference": "d9581493fce8e5c86ad9821a79cea589ef6b296e",
                 "shasum": ""
             },
             "require": {
@@ -1380,9 +1380,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-v2-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.2"
+                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.3"
             },
-            "time": "2025-08-13T07:36:21+00:00"
+            "time": "2026-02-23T10:13:28+00:00"
         },
         {
             "name": "ralouphie/getallheaders",


### PR DESCRIPTION
- Updated `composer.json` to bump version to `2.1.8`.
- Updated `composer.lock` to reflect new versions of dependencies, including `qase/php-commons` to `2.1.14`, `qase/qase-api-client` to `1.1.7`, and `qase/qase-api-v2-client` to `1.1.3`.
- Adjusted content hash in `composer.lock` to maintain integrity.