### PR TITLE
feat: add integration testing with reporters-validator

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -30,3 +30,45 @@ jobs:
 
       - name: Run tests
         run: vendor/bin/phpunit
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, intl
+          tools: composer:v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Install reporters-validator
+        run: pip install git+https://github.com/qase-tms/reporters-validator.git
+
+      - name: Download report schemas
+        run: git clone --depth 1 https://github.com/qase-tms/specs.git /tmp/specs
+
+      - name: Run example tests in report mode
+        run: |
+          QASE_MODE=report \
+          QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/report \
+          vendor/bin/phpunit -c example/phpunit-integration.xml || true
+
+      - name: Validate PHPUnit reporter
+        run: |
+          reporters-validator validate \
+            --report-dir ${{ github.workspace }}/build/report \
+            --expected expected/phpunit-examples.yaml \
+            --schema-dir /tmp/specs/report/schemas

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^8.1",
     "phpunit/phpunit": "^10 || ^11 || ^12",
-    "qase/php-commons": "^2.1.12"
+    "qase/php-commons": "^2.1.17"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95f95c92d5b773a060e50171eec6ccd3",
+    "content-hash": "5eaca8d12cbe7a6b5f78572f5025cf85",
     "packages": [
         {
             "name": "brick/math",
@@ -1219,16 +1219,16 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.1.14",
+            "version": "2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "258a7cd54949038eb3b77c9c87bc945618195610"
+                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/258a7cd54949038eb3b77c9c87bc945618195610",
-                "reference": "258a7cd54949038eb3b77c9c87bc945618195610",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
+                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
                 "shasum": ""
             },
             "require": {
@@ -1268,9 +1268,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.14"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.17"
             },
-            "time": "2026-02-17T07:36:59+00:00"
+            "time": "2026-04-06T12:01:38+00:00"
         },
         {
             "name": "qase/qase-api-client",

--- a/example/AttachmentTest.php
+++ b/example/AttachmentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Qase\PHPUnitReporter\Attributes\QaseId;
+use Qase\PHPUnitReporter\Qase;
+
+class AttachmentTest extends TestCase
+{
+    #[QaseId(30)]
+    public function testFileAttachment(): void
+    {
+        Qase::attach(__DIR__ . '/testdata/sample.txt');
+        $this->assertTrue(true);
+    }
+
+    #[QaseId(31)]
+    public function testContentAttachment(): void
+    {
+        Qase::attach((object) [
+            'title' => 'log.json',
+            'content' => '{"key": "value"}',
+            'mime' => 'application/json',
+        ]);
+        $this->assertTrue(true);
+    }
+}

--- a/example/AttributeTest.php
+++ b/example/AttributeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Qase\PHPUnitReporter\Attributes\Field;
+use Qase\PHPUnitReporter\Attributes\QaseId;
+use Qase\PHPUnitReporter\Attributes\QaseIds;
+use Qase\PHPUnitReporter\Attributes\Suite;
+use Qase\PHPUnitReporter\Attributes\Title;
+
+class AttributeTest extends TestCase
+{
+    #[QaseId(10)]
+    public function testWithQaseId(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[QaseIds([11, 12])]
+    public function testWithQaseIds(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[QaseId(13), Title("Custom title for test")]
+    public function testWithTitle(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[QaseId(14), Suite("Auth"), Suite("Login")]
+    public function testWithSuites(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[
+        QaseId(15),
+        Field("severity", "critical"),
+        Field("layer", "unit")
+    ]
+    public function testWithFields(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[
+        QaseId(16),
+        Title("Full attributes test"),
+        Suite("Smoke"),
+        Field("priority", "high")
+    ]
+    public function testWithAllAttributes(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/example/CombinedTest.php
+++ b/example/CombinedTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Qase\PHPUnitReporter\Attributes\Field;
+use Qase\PHPUnitReporter\Attributes\QaseId;
+use Qase\PHPUnitReporter\Attributes\Suite;
+use Qase\PHPUnitReporter\Qase;
+
+class CombinedTest extends TestCase
+{
+    #[QaseId(40)]
+    public function testWithComment(): void
+    {
+        Qase::comment("This is a test comment");
+        $this->assertTrue(true);
+    }
+
+    #[QaseId(41)]
+    public function testWithDynamicTitle(): void
+    {
+        Qase::title("Overridden title at runtime");
+        $this->assertTrue(true);
+    }
+
+    #[QaseId(42), Suite("Integration"), Field("component", "auth")]
+    public function testWithSuiteAndField(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/example/DataProviderTest.php
+++ b/example/DataProviderTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Qase\PHPUnitReporter\Attributes\Parameter;
+use Qase\PHPUnitReporter\Attributes\QaseId;
 use Qase\PHPUnitReporter\Attributes\Title;
 
 class DataProviderTest extends TestCase
 {
-    /**
-     * Return a list of versions to test
-     */
     public static function getProviderData(): array
     {
         return [
@@ -22,6 +20,7 @@ class DataProviderTest extends TestCase
     }
 
     #[
+        QaseId(20),
         DataProvider('getProviderData'),
         Parameter('version', ''),
         Title("Test version")
@@ -31,9 +30,6 @@ class DataProviderTest extends TestCase
         $this->assertStringContainsString('v', $version, "Version includes v");
     }
 
-    /**
-     * Simple data provider with indexed array
-     */
     public static function getSimpleData(): array
     {
         return [
@@ -44,6 +40,7 @@ class DataProviderTest extends TestCase
     }
 
     #[
+        QaseId(21),
         DataProvider('getSimpleData'),
         Title("Test simple data provider")
     ]
@@ -52,18 +49,16 @@ class DataProviderTest extends TestCase
         $this->assertNotEmpty($value);
     }
 
-    /**
-     * Data provider with associative array
-     */
     public static function getAssociativeData(): array
     {
         return [
-            ['browser' => 'chrome', 'version' => '120'],
-            ['browser' => 'firefox', 'version' => '121'],
+            [['browser' => 'chrome', 'version' => '120']],
+            [['browser' => 'firefox', 'version' => '121']],
         ];
     }
 
     #[
+        QaseId(22),
         DataProvider('getAssociativeData'),
         Title("Test associative data provider")
     ]
@@ -73,4 +68,3 @@ class DataProviderTest extends TestCase
         $this->assertArrayHasKey('version', $data);
     }
 }
-

--- a/example/ExampleTest.php
+++ b/example/ExampleTest.php
@@ -3,20 +3,23 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use Qase\PHPUnitReporter\Attributes\QaseId;
 
 class ExampleTest extends TestCase
 {
-
+    #[QaseId(1)]
     public function testSuccess(): void
     {
         $this->assertTrue(true);
     }
 
+    #[QaseId(2)]
     public function testSkipped(): void
     {
-        $this->markTestSkipped();
+        $this->markTestSkipped('Intentionally skipped');
     }
 
+    #[QaseId(3)]
     public function testFail(): void
     {
         $this->assertTrue(false);

--- a/example/phpunit-integration.xml
+++ b/example/phpunit-integration.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../vendor/autoload.php">
+    <extensions>
+        <bootstrap class="Qase\PHPUnitReporter\QaseExtension"/>
+    </extensions>
+    <testsuites>
+        <testsuite name="integration">
+            <file>ExampleTest.php</file>
+            <file>DataProviderTest.php</file>
+            <file>AttributeTest.php</file>
+            <file>AttachmentTest.php</file>
+            <file>CombinedTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/example/testdata/sample.txt
+++ b/example/testdata/sample.txt
@@ -1,0 +1,1 @@
+This is a sample text file for attachment testing.

--- a/expected/phpunit-examples.yaml
+++ b/expected/phpunit-examples.yaml
@@ -1,0 +1,260 @@
+run:
+  stats:
+    passed: 20
+    failed: 1
+    skipped: 1
+    broken: 0
+    muted: 0
+    total: 22
+results:
+- title: Test simple data provider
+  signature: 21::dataprovidertest::{"param0":"value1"}
+  testops_ids:
+  - 21
+  status: passed
+  params:
+    param0: value1
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null
+- title: testFail
+  signature: 3::exampletest
+  testops_ids:
+  - 3
+  status: failed
+  relations:
+    suite:
+      data:
+      - title: ExampleTest
+        public_id: null
+- title: Test simple data provider
+  signature: 21::dataprovidertest::{"param0":"value3"}
+  testops_ids:
+  - 21
+  status: passed
+  params:
+    param0: value3
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null
+- title: Test associative data provider
+  signature: 22::dataprovidertest::{"param0":"{"browser":"firefox","version":"121"}"}
+  testops_ids:
+  - 22
+  status: passed
+  params:
+    param0: '{"browser":"firefox","version":"121"}'
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null
+- title: Test version
+  signature: 20::dataprovidertest::{"version":"v2"}
+  testops_ids:
+  - 20
+  status: passed
+  params:
+    version: v2
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null
+- title: testSkipped
+  signature: 2::exampletest
+  testops_ids:
+  - 2
+  status: skipped
+  relations:
+    suite:
+      data:
+      - title: ExampleTest
+        public_id: null
+- title: Custom title for test
+  signature: 13::attributetest
+  testops_ids:
+  - 13
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: AttributeTest
+        public_id: null
+- title: testWithQaseId
+  signature: 10::attributetest
+  testops_ids:
+  - 10
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: AttributeTest
+        public_id: null
+- title: testWithSuites
+  signature: 14::auth::login
+  testops_ids:
+  - 14
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: Auth
+        public_id: null
+      - title: Login
+        public_id: null
+- title: testWithQaseIds
+  signature: 11-12::attributetest
+  testops_ids:
+  - 11
+  - 12
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: AttributeTest
+        public_id: null
+- title: testSuccess
+  signature: 1::exampletest
+  testops_ids:
+  - 1
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: ExampleTest
+        public_id: null
+- title: Overridden title at runtime
+  signature: 41::combinedtest
+  testops_ids:
+  - 41
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: CombinedTest
+        public_id: null
+- title: Test simple data provider
+  signature: 21::dataprovidertest::{"param0":"value2"}
+  testops_ids:
+  - 21
+  status: passed
+  params:
+    param0: value2
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null
+- title: Full attributes test
+  signature: 16::smoke
+  testops_ids:
+  - 16
+  status: passed
+  fields:
+    priority: high
+  relations:
+    suite:
+      data:
+      - title: Smoke
+        public_id: null
+- title: Test version
+  signature: 20::dataprovidertest::{"version":"v3"}
+  testops_ids:
+  - 20
+  status: passed
+  params:
+    version: v3
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null
+- title: Test associative data provider
+  signature: 22::dataprovidertest::{"param0":"{"browser":"chrome","version":"120"}"}
+  testops_ids:
+  - 22
+  status: passed
+  params:
+    param0: '{"browser":"chrome","version":"120"}'
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null
+- title: testWithComment
+  signature: 40::combinedtest
+  testops_ids:
+  - 40
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: CombinedTest
+        public_id: null
+- title: testFileAttachment
+  signature: 30::attachmenttest
+  testops_ids:
+  - 30
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: AttachmentTest
+        public_id: null
+  attachments:
+  - {}
+- title: testContentAttachment
+  signature: 31::attachmenttest
+  testops_ids:
+  - 31
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: AttachmentTest
+        public_id: null
+  attachments:
+  - file_name: log.json
+    mime_type: application/json
+- title: testWithSuiteAndField
+  signature: 42::integration
+  testops_ids:
+  - 42
+  status: passed
+  fields:
+    component: auth
+  relations:
+    suite:
+      data:
+      - title: Integration
+        public_id: null
+- title: testWithFields
+  signature: 15::attributetest
+  testops_ids:
+  - 15
+  status: passed
+  fields:
+    severity: critical
+    layer: unit
+  relations:
+    suite:
+      data:
+      - title: AttributeTest
+        public_id: null
+- title: Test version
+  signature: 20::dataprovidertest::{"version":"v1"}
+  testops_ids:
+  - 20
+  status: passed
+  params:
+    version: v1
+  relations:
+    suite:
+      data:
+      - title: DataProviderTest
+        public_id: null

--- a/scripts/clean_expected.py
+++ b/scripts/clean_expected.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Clean up expected YAML files by removing dynamic and empty fields."""
+
+import sys
+import yaml
+from pathlib import Path
+
+
+def clean_result(result: dict) -> dict:
+    """Remove dynamic, empty, and default fields from a result."""
+    out = {}
+
+    if result.get("title"):
+        out["title"] = result["title"]
+    if result.get("signature"):
+        out["signature"] = result["signature"]
+    if result.get("testops_ids"):
+        out["testops_ids"] = result["testops_ids"]
+
+    status = result.get("status") or (result.get("execution", {}) or {}).get("status")
+    if status:
+        out["status"] = status
+
+    fields = result.get("fields")
+    if fields and fields != {}:
+        out["fields"] = fields
+
+    params = result.get("params")
+    if params and params != {}:
+        out["params"] = params
+
+    relations = result.get("relations")
+    if relations and relations.get("suite", {}).get("data"):
+        out["relations"] = relations
+
+    steps = result.get("steps")
+    if steps and steps != []:
+        out["steps"] = [clean_step(s) for s in steps]
+
+    attachments = result.get("attachments")
+    if attachments and attachments != []:
+        out["attachments"] = [clean_attachment(a) for a in attachments]
+
+    if result.get("muted"):
+        out["muted"] = True
+
+    return out
+
+
+def clean_step(step: dict) -> dict:
+    """Clean a step, removing IDs and timestamps."""
+    out = {}
+
+    data = step.get("data")
+    if data:
+        clean_data = {}
+        if data.get("action"):
+            clean_data["action"] = data["action"]
+        if data.get("expected_result"):
+            clean_data["expected_result"] = data["expected_result"]
+        if clean_data:
+            out["data"] = clean_data
+
+    exec_block = step.get("execution", {}) or {}
+    if exec_block.get("status"):
+        out["execution"] = {"status": exec_block["status"]}
+
+    child_steps = step.get("steps")
+    if child_steps and child_steps != []:
+        out["steps"] = [clean_step(s) for s in child_steps]
+
+    return out
+
+
+def clean_attachment(att: dict) -> dict:
+    """Keep only file_name and mime_type."""
+    out = {}
+    if att.get("file_name"):
+        out["file_name"] = att["file_name"]
+    if att.get("mime_type"):
+        out["mime_type"] = att["mime_type"]
+    return out
+
+
+def clean_expected(data: dict) -> dict:
+    """Clean an entire expected file."""
+    out = {}
+
+    if data.get("run"):
+        out["run"] = data["run"]
+
+    if data.get("results"):
+        out["results"] = [clean_result(r) for r in data["results"]]
+
+    return out
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: clean_expected.py <file.yaml> [file2.yaml ...]")
+        sys.exit(1)
+
+    for path_str in sys.argv[1:]:
+        path = Path(path_str)
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+
+        cleaned = clean_expected(data)
+
+        with open(path, "w") as f:
+            yaml.dump(cleaned, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+        print(f"Cleaned: {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add example tests covering all reporter features: pass/fail/skip, QaseId, QaseIds, Title, Suite, Field, Parameter, DataProvider, Attachment, Comment (22 tests total)
- Add `reporters-validator` integration in CI that validates JSON report output against JSON Schema and expected YAML data
- Update `php-commons` to `^2.1.17` (fixes params serialization and attachment id)

## What's included

**Example tests** (`example/`):
- `ExampleTest.php` — basic statuses (pass, fail, skip) with QaseIds
- `DataProviderTest.php` — parameter pairs, indexed, associative data providers
- `AttributeTest.php` — QaseId, QaseIds, Title, Suite, Field attributes
- `AttachmentTest.php` — file and content attachments
- `CombinedTest.php` — Comment, dynamic Title, Suite+Field combo

**Validation infrastructure**:
- `expected/phpunit-examples.yaml` — expected reporter output (cleaned of dynamic fields)
- `scripts/clean_expected.py` — removes timestamps, IDs, stacktraces from expected YAML
- `example/phpunit-integration.xml` — PHPUnit config for integration test suite

**CI** (`.github/workflows/php.yml`):
- New `integration-test` job that runs after unit tests
- Installs `reporters-validator`, clones `qase-tms/specs` for schemas
- Runs examples in `QASE_MODE=report`, validates output

## Test plan

- [x] CI `build` job passes (unit tests on PHP 8.1-8.4)
- [x] CI `integration-test` job passes (`All validations passed.`)
- [x] Verify each example test has a unique QaseId (no signature collisions)