### PR TITLE
feat: add Tags attribute support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^8.1",
     "phpunit/phpunit": "^10 || ^11 || ^12",
-    "qase/php-commons": "^2.1.17"
+    "qase/php-commons": "^2.1.18"
   },
   "autoload": {
     "psr-4": {
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.1.8",
+  "version": "2.1.9",
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5eaca8d12cbe7a6b5f78572f5025cf85",
+    "content-hash": "fe29c8af864ff1a3cefe277987eba3dc",
     "packages": [
         {
             "name": "brick/math",
@@ -277,16 +277,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -302,6 +302,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -373,7 +374,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -389,7 +390,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1219,22 +1220,22 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.1.17",
+            "version": "2.1.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54"
+                "reference": "ca0459b6b97a7810a7aa1db15297f864827556d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
-                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/ca0459b6b97a7810a7aa1db15297f864827556d0",
+                "reference": "ca0459b6b97a7810a7aa1db15297f864827556d0",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.0",
                 "qase/qase-api-client": "^1.1.5",
-                "qase/qase-api-v2-client": "^1.1.2",
+                "qase/qase-api-v2-client": "^1.1.5",
                 "ramsey/uuid": "^4.7"
             },
             "require-dev": {
@@ -1268,22 +1269,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.17"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.18"
             },
-            "time": "2026-04-06T12:01:38+00:00"
+            "time": "2026-04-09T08:02:34+00:00"
         },
         {
             "name": "qase/qase-api-client",
-            "version": "1.1.7",
+            "version": "1.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-client.git",
-                "reference": "ecfaf6bebd8a42e17ce891364ea11f3eac1e830d"
+                "reference": "edde038fcc858cd342eb900c076524798f635772"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/ecfaf6bebd8a42e17ce891364ea11f3eac1e830d",
-                "reference": "ecfaf6bebd8a42e17ce891364ea11f3eac1e830d",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/edde038fcc858cd342eb900c076524798f635772",
+                "reference": "edde038fcc858cd342eb900c076524798f635772",
                 "shasum": ""
             },
             "require": {
@@ -1324,22 +1325,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.7"
+                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.10"
             },
-            "time": "2026-02-23T10:22:14+00:00"
+            "time": "2026-03-26T13:32:24+00:00"
         },
         {
             "name": "qase/qase-api-v2-client",
-            "version": "1.1.3",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-v2-client.git",
-                "reference": "d9581493fce8e5c86ad9821a79cea589ef6b296e"
+                "reference": "9cc363fc035bd66b8bdae5cf894525136d660000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/d9581493fce8e5c86ad9821a79cea589ef6b296e",
-                "reference": "d9581493fce8e5c86ad9821a79cea589ef6b296e",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/9cc363fc035bd66b8bdae5cf894525136d660000",
+                "reference": "9cc363fc035bd66b8bdae5cf894525136d660000",
                 "shasum": ""
             },
             "require": {
@@ -1380,9 +1381,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-v2-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.3"
+                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.5"
             },
-            "time": "2026-02-23T10:13:28+00:00"
+            "time": "2026-04-07T12:51:13+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,7 @@ This guide covers all available annotations and methods for using the Qase PHPUn
   - [Title](#title)
   - [Suite](#suite)
   - [Field](#field)
+  - [Tags](#tags)
   - [Parameter](#parameter)
 - [Methods](#methods)
   - [Qase::comment()](#qasecomment)
@@ -119,6 +120,48 @@ public function testUserLogin(): void
 }
 ```
 
+### Tags
+
+Adds tags to the test case in Qase.
+
+**Target:** Method and Class
+**Repeatable:** Yes
+
+```php
+use Qase\PHPUnitReporter\Attributes\Tags;
+
+// Single attribute with multiple tags
+#[Tags('smoke', 'regression')]
+public function testUserLogin(): void
+{
+    // Test implementation
+}
+
+// Multiple Tags attributes (accumulated)
+#[Tags('smoke')]
+#[Tags('regression')]
+public function testUserLogin(): void
+{
+    // Test implementation
+}
+
+// Class-level + method-level (merged)
+#[Tags('smoke')]
+class AuthTest extends TestCase
+{
+    #[Tags('regression')]
+    public function testLogin(): void
+    {
+        // This test will have tags: ['smoke', 'regression']
+    }
+
+    public function testLogout(): void
+    {
+        // This test will have tags: ['smoke']
+    }
+}
+```
+
 ### Parameter
 
 Adds parameters to the test case in Qase.
@@ -215,6 +258,7 @@ use Qase\PHPUnitReporter\Attributes\Field;
 use Qase\PHPUnitReporter\Attributes\Parameter;
 use Qase\PHPUnitReporter\Attributes\QaseId;
 use Qase\PHPUnitReporter\Attributes\Suite;
+use Qase\PHPUnitReporter\Attributes\Tags;
 use Qase\PHPUnitReporter\Attributes\Title;
 use Qase\PHPUnitReporter\Qase;
 
@@ -291,22 +335,25 @@ namespace Tests;
 use PHPUnit\Framework\TestCase;
 use Qase\PHPUnitReporter\Attributes\Field;
 use Qase\PHPUnitReporter\Attributes\Suite;
+use Qase\PHPUnitReporter\Attributes\Tags;
 
 #[
     Suite('API Tests'),
     Field('environment', 'staging'),
-    Field('api_version', 'v2')
+    Field('api_version', 'v2'),
+    Tags('smoke')
 ]
 class ApiTest extends TestCase
 {
-    // All test methods inherit the suite and fields from class annotations
-    
+    // All test methods inherit the suite, fields, and tags from class annotations
+
     public function testGetUser(): void
     {
         // This test will be assigned to 'API Tests' suite
         // and have environment=staging, api_version=v2 fields
+        // and tags: ['smoke']
     }
-    
+
     public function testCreateUser(): void
     {
         // Same inheritance applies here
@@ -379,6 +426,8 @@ public function testWithEvidence(): void
 ### 6. Combine Annotations Effectively
 
 ```php
+use Qase\PHPUnitReporter\Attributes\Tags;
+
 #[
     QaseId(123),
     Title('User Login with Valid Credentials'),
@@ -386,6 +435,7 @@ public function testWithEvidence(): void
     Suite('Smoke Tests'),
     Field('severity', 'high'),
     Field('priority', 'P1'),
+    Tags('smoke'),
     Parameter('browser', 'chrome'),
     Parameter('environment', 'staging')
 ]

--- a/example/AttributeTest.php
+++ b/example/AttributeTest.php
@@ -7,8 +7,10 @@ use Qase\PHPUnitReporter\Attributes\Field;
 use Qase\PHPUnitReporter\Attributes\QaseId;
 use Qase\PHPUnitReporter\Attributes\QaseIds;
 use Qase\PHPUnitReporter\Attributes\Suite;
+use Qase\PHPUnitReporter\Attributes\Tags;
 use Qase\PHPUnitReporter\Attributes\Title;
 
+#[Tags("smoke")]
 class AttributeTest extends TestCase
 {
     #[QaseId(10)]
@@ -49,7 +51,8 @@ class AttributeTest extends TestCase
         QaseId(16),
         Title("Full attributes test"),
         Suite("Smoke"),
-        Field("priority", "high")
+        Field("priority", "high"),
+        Tags("regression")
     ]
     public function testWithAllAttributes(): void
     {

--- a/expected/phpunit-examples.yaml
+++ b/expected/phpunit-examples.yaml
@@ -80,6 +80,7 @@ results:
   testops_ids:
   - 13
   status: passed
+  tags: smoke
   relations:
     suite:
       data:
@@ -90,6 +91,7 @@ results:
   testops_ids:
   - 10
   status: passed
+  tags: smoke
   relations:
     suite:
       data:
@@ -100,6 +102,7 @@ results:
   testops_ids:
   - 14
   status: passed
+  tags: smoke
   relations:
     suite:
       data:
@@ -113,6 +116,7 @@ results:
   - 11
   - 12
   status: passed
+  tags: smoke
   relations:
     suite:
       data:
@@ -157,6 +161,7 @@ results:
   status: passed
   fields:
     priority: high
+  tags: smoke,regression
   relations:
     suite:
       data:
@@ -241,6 +246,7 @@ results:
   fields:
     severity: critical
     layer: unit
+  tags: smoke
   relations:
     suite:
       data:

--- a/src/Attributes/AttributeParser.php
+++ b/src/Attributes/AttributeParser.php
@@ -83,6 +83,10 @@ class AttributeParser implements AttributeParserInterface
             if ($annotation instanceof ParameterAttributeInterface) {
                 $metadata->parameters[$annotation->getName()] = $annotation->getValue();
             }
+
+            if ($annotation instanceof TagsAttributeInterface) {
+                $metadata->tags = array_merge($metadata->tags, $annotation->getTags());
+            }
         }
 
         return $metadata;

--- a/src/Attributes/Tags.php
+++ b/src/Attributes/Tags.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Qase\PHPUnitReporter\Attributes;
+
+use Attribute;
+
+/**
+ * Add tags to a test case in Qase
+ * Example:
+ * #[Tags("smoke", "regression")]
+ * public function testOne(): void
+ * {
+ *    $this->assertTrue(true);
+ * }
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class Tags implements TagsAttributeInterface
+{
+    /** @var string[] */
+    private array $tags;
+
+    public function __construct(string ...$values)
+    {
+        $this->tags = $values;
+    }
+
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+}

--- a/src/Attributes/TagsAttributeInterface.php
+++ b/src/Attributes/TagsAttributeInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Qase\PHPUnitReporter\Attributes;
+
+interface TagsAttributeInterface extends AttributeInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getTags(): array;
+}

--- a/src/Models/Metadata.php
+++ b/src/Models/Metadata.php
@@ -9,4 +9,5 @@ class Metadata
     public array $suites = [];
     public array $parameters = [];
     public array $fields = [];
+    public array $tags = [];
 }

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -79,6 +79,7 @@ class QaseReporter implements QaseReporterInterface
         }
 
         $testResult->fields = $metadata->fields;
+        $testResult->tags = $metadata->tags;
         $testResult->params = $mergedParams;
         $testResult->signature = $this->createSignature($test, $metadata->qaseIds, $metadata->suites, $mergedParams);
         $testResult->execution->setThread($this->getThread());

--- a/tests/AttributeParserTest.php
+++ b/tests/AttributeParserTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Qase\PHPUnitReporter\Attributes\AttributeParser;
+use Qase\PHPUnitReporter\Attributes\AttributeReader;
+use Qase\PhpCommons\Loggers\Logger;
+
+class AttributeParserTest extends TestCase
+{
+    private AttributeParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new AttributeParser(new Logger(), new AttributeReader());
+    }
+
+    public function testParseTagsFromSingleAttribute(): void
+    {
+        $metadata = $this->parser->parseAttribute(TagsTestFixture::class, 'testWithSingleTagsAttribute');
+        $this->assertSame(['smoke', 'regression'], $metadata->tags);
+    }
+
+    public function testParseTagsFromMultipleAttributes(): void
+    {
+        $metadata = $this->parser->parseAttribute(TagsTestFixture::class, 'testWithMultipleTagsAttributes');
+        $this->assertSame(['smoke', 'regression'], $metadata->tags);
+    }
+
+    public function testMergeClassAndMethodTags(): void
+    {
+        $metadata = $this->parser->parseAttribute(ClassLevelTagsFixture::class, 'testWithMethodTags');
+        $this->assertSame(['smoke', 'regression'], $metadata->tags);
+    }
+
+    public function testClassTagsInheritedByMethodWithoutTags(): void
+    {
+        $metadata = $this->parser->parseAttribute(ClassLevelTagsFixture::class, 'testWithoutTags');
+        $this->assertSame(['smoke'], $metadata->tags);
+    }
+
+    public function testEmptyTags(): void
+    {
+        $metadata = $this->parser->parseAttribute(TagsTestFixture::class, 'testWithoutTags');
+        $this->assertSame([], $metadata->tags);
+    }
+
+    public function testAllAttributesTogether(): void
+    {
+        $metadata = $this->parser->parseAttribute(TagsTestFixture::class, 'testWithAllAttributes');
+        $this->assertSame('Custom title', $metadata->title);
+        $this->assertSame([100], $metadata->qaseIds);
+        $this->assertSame(['Auth'], $metadata->suites);
+        $this->assertSame(['severity' => 'high'], $metadata->fields);
+        $this->assertSame(['smoke', 'regression'], $metadata->tags);
+    }
+}

--- a/tests/ClassLevelTagsFixture.php
+++ b/tests/ClassLevelTagsFixture.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Qase\PHPUnitReporter\Attributes\Tags;
+
+#[Tags('smoke')]
+class ClassLevelTagsFixture
+{
+    #[Tags('regression')]
+    public function testWithMethodTags(): void {}
+
+    public function testWithoutTags(): void {}
+}

--- a/tests/TagsTestFixture.php
+++ b/tests/TagsTestFixture.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Qase\PHPUnitReporter\Attributes\Field;
+use Qase\PHPUnitReporter\Attributes\QaseId;
+use Qase\PHPUnitReporter\Attributes\Suite;
+use Qase\PHPUnitReporter\Attributes\Tags;
+use Qase\PHPUnitReporter\Attributes\Title;
+
+class TagsTestFixture
+{
+    #[Tags('smoke', 'regression')]
+    public function testWithSingleTagsAttribute(): void {}
+
+    #[Tags('smoke')]
+    #[Tags('regression')]
+    public function testWithMultipleTagsAttributes(): void {}
+
+    public function testWithoutTags(): void {}
+
+    #[QaseId(100)]
+    #[Title('Custom title')]
+    #[Suite('Auth')]
+    #[Field('severity', 'high')]
+    #[Tags('smoke', 'regression')]
+    public function testWithAllAttributes(): void {}
+}


### PR DESCRIPTION
## Summary
- Add `#[Tags('smoke', 'regression')]` attribute (repeatable, class+method)
- Tags from class and method levels are merged (accumulated)
- Update examples, expected YAML, docs, unit tests (6 new tests)
- Bump version to 2.1.9, depends on php-commons ^2.1.18

## Test plan
- [x] Run `composer test` — all 14 tests pass
- [x] Verify class-level tags inherited by all methods
- [x] Verify class+method tags merge correctly
- [x] Review docs/usage.md Tags section