### PR TITLE
fix: stable TestMethod key to avoid null execution under paratest+coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.1.9",
+  "version": "2.1.10",
   "scripts": {
     "test": "phpunit"
   },

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -122,22 +122,44 @@ class QaseReporter implements QaseReporterInterface
     public function completeTest(TestMethod $test): void
     {
         $key = $this->getTestKey($test);
+
+        if (!isset($this->testResults[$key])) {
+            $this->startTest($test);
+        }
+
         $this->testResults[$key]->execution->finish();
 
         $this->reporter->addResult($this->testResults[$key]);
     }
 
+    /**
+     * Build a stable, deterministic key for a test invocation.
+     *
+     * Uses only native PHPUnit stable data (className, methodName, line
+     * and the data set name exposed by the public testData() API).
+     * This intentionally avoids reflection/invocation of the data
+     * provider method here, because those can produce different
+     * results between consecutive calls under paratest +
+     * XDEBUG_MODE=coverage (or PHP 8.4 deprecations), which used to
+     * cause the key computed in startTest() to differ from the key
+     * computed later in updateStatus()/completeTest() and ended up
+     * dereferencing a null Result/execution.
+     */
     private function getTestKey(TestMethod $test): string
     {
         $baseKey = $test->className() . '::' . $test->methodName() . ':' . $test->line();
-        
-        // Include data provider data in key to make each iteration unique
-        $dataProviderParams = $this->extractDataProviderParams($test);
-        if (!empty($dataProviderParams)) {
-            $paramsHash = $this->generateParamsHash($dataProviderParams);
-            return $baseKey . ':' . $paramsHash;
+
+        try {
+            $testData = $test->testData();
+            if (method_exists($testData, 'hasDataFromDataProvider')
+                && $testData->hasDataFromDataProvider()) {
+                $dataSetName = $testData->dataFromDataProvider()->dataSetName();
+                return $baseKey . '#' . $dataSetName;
+            }
+        } catch (\Throwable $e) {
+            // Fall through to the base key.
         }
-        
+
         return $baseKey;
     }
 
@@ -477,16 +499,4 @@ class QaseReporter implements QaseReporterInterface
         return 'empty';
     }
 
-    /**
-     * Generate a hash from parameters for use in test key
-     * 
-     * @param array<string, string> $params
-     * @return string
-     */
-    private function generateParamsHash(array $params): string
-    {
-        ksort($params);
-        $paramString = http_build_query($params);
-        return md5($paramString);
-    }
 }


### PR DESCRIPTION
## Summary
- Replace reflection/invoke-based `getTestKey()` with a stable key built from PHPUnit's public `TestMethod` API (className/methodName/line/dataSetName).
- Add defensive `startTest()` fallback in `completeTest()` to mirror `updateStatus()`.
- Drop now-unused `generateParamsHash()`.

## Problem
Under `XDEBUG_MODE=coverage` with `paratest` (and on PHP 8.4 where reflection on private properties is stricter), the previous `getTestKey()` could succeed during `Prepared` (storing the `Result` under key A) but silently fail inside `extractDataProviderParams()` during `Passed`/`Finished` (returning `[]`, yielding key B). That mismatch left `$this->testResults[$key]` unset, so `->execution->setStatus()` / `->execution->finish()` crashed with:

```
Exception in third-party event subscriber: Call to a member function setStatus() on null
Exception in third-party event subscriber: Call to a member function finish() on null
```

## Fix
- `getTestKey()` now uses only stable, publicly exposed data. No data-provider invocation, no private-field reflection.
- `completeTest()` lazily `startTest()`s if `Prepared` didn't land.
- Verified keys match across `Prepared`/`Passed`/`Finished` for both parameterized and plain tests via a standalone extension harness.

## Test plan
- [x] `vendor/bin/phpunit tests/` — 14/14 pass
- [x] PHP lint clean (`php -l src/QaseReporter.php`)
- [x] Real-phpunit smoke extension: same key emitted across Prepared/Passed/Finished for data-provider and plain tests