### PR TITLE
a number of fixes for v2 reporter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.1.10",
+  "version": "2.1.11",
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe29c8af864ff1a3cefe277987eba3dc",
+    "content-hash": "db6f54b5476a7c54c78a5770d4087fdf",
     "packages": [
         {
             "name": "brick/math",
@@ -1220,16 +1220,16 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.1.18",
+            "version": "2.1.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "ca0459b6b97a7810a7aa1db15297f864827556d0"
+                "reference": "6dfc55b5d9428ec3cbded48ea4d35c7cbf8ea314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/ca0459b6b97a7810a7aa1db15297f864827556d0",
-                "reference": "ca0459b6b97a7810a7aa1db15297f864827556d0",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/6dfc55b5d9428ec3cbded48ea4d35c7cbf8ea314",
+                "reference": "6dfc55b5d9428ec3cbded48ea4d35c7cbf8ea314",
                 "shasum": ""
             },
             "require": {
@@ -1269,9 +1269,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.18"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.20"
             },
-            "time": "2026-04-09T08:02:34+00:00"
+            "time": "2026-04-16T11:00:48+00:00"
         },
         {
             "name": "qase/qase-api-client",

--- a/expected/phpunit-examples.yaml
+++ b/expected/phpunit-examples.yaml
@@ -8,7 +8,7 @@ run:
     total: 22
 results:
 - title: Test simple data provider
-  signature: 21::dataprovidertest::{"param0":"value1"}
+  signature: 21::dataprovidertest::{"param0":"value1"}::0
   testops_ids:
   - 21
   status: passed
@@ -30,7 +30,7 @@ results:
       - title: ExampleTest
         public_id: null
 - title: Test simple data provider
-  signature: 21::dataprovidertest::{"param0":"value3"}
+  signature: 21::dataprovidertest::{"param0":"value3"}::2
   testops_ids:
   - 21
   status: passed
@@ -42,7 +42,7 @@ results:
       - title: DataProviderTest
         public_id: null
 - title: Test associative data provider
-  signature: 22::dataprovidertest::{"param0":"{"browser":"firefox","version":"121"}"}
+  signature: 22::dataprovidertest::{"param0":"{"browser":"firefox","version":"121"}"}::1
   testops_ids:
   - 22
   status: passed
@@ -54,7 +54,7 @@ results:
       - title: DataProviderTest
         public_id: null
 - title: Test version
-  signature: 20::dataprovidertest::{"version":"v2"}
+  signature: 20::dataprovidertest::{"version":"v2"}::v2
   testops_ids:
   - 20
   status: passed
@@ -143,7 +143,7 @@ results:
       - title: CombinedTest
         public_id: null
 - title: Test simple data provider
-  signature: 21::dataprovidertest::{"param0":"value2"}
+  signature: 21::dataprovidertest::{"param0":"value2"}::1
   testops_ids:
   - 21
   status: passed
@@ -168,7 +168,7 @@ results:
       - title: Smoke
         public_id: null
 - title: Test version
-  signature: 20::dataprovidertest::{"version":"v3"}
+  signature: 20::dataprovidertest::{"version":"v3"}::v3
   testops_ids:
   - 20
   status: passed
@@ -180,7 +180,7 @@ results:
       - title: DataProviderTest
         public_id: null
 - title: Test associative data provider
-  signature: 22::dataprovidertest::{"param0":"{"browser":"chrome","version":"120"}"}
+  signature: 22::dataprovidertest::{"param0":"{"browser":"chrome","version":"120"}"}::0
   testops_ids:
   - 22
   status: passed
@@ -253,7 +253,7 @@ results:
       - title: AttributeTest
         public_id: null
 - title: Test version
-  signature: 20::dataprovidertest::{"version":"v1"}
+  signature: 20::dataprovidertest::{"version":"v1"}::v1
   testops_ids:
   - 20
   status: passed

--- a/src/Events/TestPreparationErroredSubscriber.php
+++ b/src/Events/TestPreparationErroredSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PHPUnitReporter\Events;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Test\PreparationErrored;
+use PHPUnit\Event\Test\PreparationErroredSubscriber;
+use Qase\PHPUnitReporter\QaseReporterInterface;
+
+final class TestPreparationErroredSubscriber implements PreparationErroredSubscriber
+{
+    private QaseReporterInterface $reporter;
+
+    public function __construct(
+        QaseReporterInterface $reporter
+    )
+    {
+        $this->reporter = $reporter;
+    }
+
+    public function notify(PreparationErrored $event): void
+    {
+        $test = $event->test();
+
+        if (!($test instanceof TestMethod)) {
+            return;
+        }
+
+        $throwable = $event->throwable();
+
+        $this->reporter->updateStatus($test, 'failed', $throwable->message(), $throwable->asString());
+    }
+}

--- a/src/QaseExtension.php
+++ b/src/QaseExtension.php
@@ -24,19 +24,25 @@ final class QaseExtension implements Extension
 
         $reporter = QaseReporter::getInstance($attributeParser, $coreReporter);
         
-        $facade->registerSubscribers(
-            new Events\TestConsideredRiskySubscriber($reporter),
+        $subscribers = [
+            new Events\TestRunnerStartedSubscriber($reporter),
             new Events\TestPreparedSubscriber($reporter),
-            new Events\TestFinishedSubscriber($reporter),
+            new Events\TestPassedSubscriber($reporter),
             new Events\TestFailedSubscriber($reporter),
             new Events\TestErroredSubscriber($reporter),
-            new Events\TestMarkedIncompleteSubscriber($reporter),
             new Events\TestSkippedSubscriber($reporter),
-            new Events\TestWarningTriggeredSubscriber($reporter),
+            new Events\TestMarkedIncompleteSubscriber($reporter),
             new Events\TestConsideredRiskySubscriber($reporter),
-            new Events\TestPassedSubscriber($reporter),
+            new Events\TestWarningTriggeredSubscriber($reporter),
+            new Events\TestFinishedSubscriber($reporter),
             new Events\TestRunnerFinishedSubscriber($reporter),
-            new Events\TestRunnerStartedSubscriber($reporter),
-        );
+        ];
+
+        // PreparationErrored is available in PHPUnit 11.4+/12+
+        if (interface_exists(\PHPUnit\Event\Test\PreparationErroredSubscriber::class)) {
+            $subscribers[] = new Events\TestPreparationErroredSubscriber($reporter);
+        }
+
+        $facade->registerSubscribers(...$subscribers);
     }
 }

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -323,6 +323,11 @@ class QaseReporter implements QaseReporterInterface
         }
         
         $result = $method->invoke(null);
+
+        if ($result instanceof \Traversable) {
+            $result = iterator_to_array($result);
+        }
+
         return is_array($result) ? $result : null;
     }
 

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -285,22 +285,28 @@ class QaseReporter implements QaseReporterInterface
     private function getOriginalDataProviderData(TestMethod $test): ?array
     {
         try {
-            $dataProviderMethodName = $this->getDataProviderMethodName($test);
-            if ($dataProviderMethodName === null) {
+            $providerNames = $this->getDataProviderMethodNames($test);
+            if (empty($providerNames)) {
                 return null;
             }
-            
-            $allDataSets = $this->invokeDataProviderMethod($test->className(), $dataProviderMethodName);
-            if (!is_array($allDataSets)) {
-                return null;
-            }
-            
+
             $dataSetName = $this->getCurrentDataSetName($test);
             if ($dataSetName === null) {
                 return null;
             }
-            
-            return $this->findDataSet($allDataSets, $dataSetName);
+
+            foreach ($providerNames as $providerName) {
+                $allDataSets = $this->invokeDataProviderMethod($test->className(), $providerName);
+                if (!is_array($allDataSets)) {
+                    continue;
+                }
+                $found = $this->findDataSet($allDataSets, $dataSetName);
+                if ($found !== null) {
+                    return $found;
+                }
+            }
+
+            return null;
         } catch (\Throwable $e) {
             return null;
         }
@@ -309,21 +315,25 @@ class QaseReporter implements QaseReporterInterface
     /**
      * Get data provider method name from test method attributes
      */
-    private function getDataProviderMethodName(TestMethod $test): ?string
+    /**
+     * @return string[]
+     */
+    private function getDataProviderMethodNames(TestMethod $test): array
     {
+        $names = [];
         $testReflection = new \ReflectionMethod($test->className(), $test->methodName());
-        
+
         foreach ($testReflection->getAttributes() as $attribute) {
             $attributeName = $attribute->getName();
             if (strpos($attributeName, 'DataProvider') !== false) {
                 $args = $attribute->getArguments();
                 if (!empty($args) && is_string($args[0])) {
-                    return $args[0];
+                    $names[] = $args[0];
                 }
             }
         }
-        
-        return null;
+
+        return $names;
     }
 
     /**

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -69,14 +69,10 @@ class QaseReporter implements QaseReporterInterface
             }
         }
 
-        // Flush buffered results without completing the run.
-        // completeRun() is deferred to the shutdown function to prevent
-        // paratest's WrapperRunner from calling startRun/completeRun per
-        // test file, which causes StateManager count to prematurely reach
-        // zero and split results across multiple runs.
-        if (method_exists($this->reporter, 'sendResults')) {
-            $this->reporter->sendResults();
-        }
+        // Results are flushed by completeRun() in the shutdown function.
+        // We intentionally do NOT call sendResults() here because
+        // FileReporter.sendResults() does not clear its buffer,
+        // causing results to be written twice.
     }
 
     public function startTest(TestMethod $test): void

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -248,7 +248,26 @@ class QaseReporter implements QaseReporterInterface
         try {
             $originalData = $this->getOriginalDataProviderData($test);
             if ($originalData !== null && is_array($originalData)) {
-                return $this->normalizeDataProviderData($originalData);
+                $normalized = $this->normalizeDataProviderData($originalData);
+
+                $hasOpaque = false;
+                foreach ($normalized as $value) {
+                    if ($value === '{}') {
+                        $hasOpaque = true;
+                        break;
+                    }
+                }
+
+                if ($hasOpaque) {
+                    $fallback = (string) ($this->getCurrentDataSetName($test) ?? '0');
+                    foreach ($normalized as $key => $value) {
+                        if ($value === '{}') {
+                            $normalized[$key] = $fallback;
+                        }
+                    }
+                }
+
+                return $normalized;
             }
             return [];
         } catch (\Throwable $e) {

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -487,7 +487,7 @@ class QaseReporter implements QaseReporterInterface
 
         if (is_scalar($value)) {
             $str = (string)$value;
-            return $str === '' ? 'empty' : $str;
+            return trim($str) === '' ? 'empty' : $str;
         }
 
         if (is_array($value)) {

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -13,11 +13,15 @@ use Qase\PHPUnitReporter\Attributes\AttributeParserInterface;
 
 class QaseReporter implements QaseReporterInterface
 {
+    private const OPAQUE_VALUE = '{}';
+
     private static QaseReporter $instance;
     private array $testResults = [];
     private AttributeParserInterface $attributeParser;
     private ReporterInterface $reporter;
     private ?string $currentKey = null;
+    private bool $runStarted = false;
+    private array $reportedKeys = [];
 
     private function __construct(AttributeParserInterface $attributeParser, ReporterInterface $reporter)
     {
@@ -40,12 +44,39 @@ class QaseReporter implements QaseReporterInterface
 
     public function startTestRun(): void
     {
+        if ($this->runStarted) {
+            return;
+        }
+
         $this->reporter->startRun();
+        $this->runStarted = true;
+
+        register_shutdown_function(function () {
+            $this->reporter->completeRun();
+        });
     }
 
     public function completeTestRun(): void
     {
-        $this->reporter->completeRun();
+        // Report tests that never received a TestFinished event.
+        // In PHPUnit 12, tests that error during setUp() may not dispatch
+        // TestFinished, leaving results in $testResults but never sent.
+        // Their execution time was already stamped by updateStatus().
+        foreach ($this->testResults as $key => $result) {
+            if (!isset($this->reportedKeys[$key])) {
+                $this->reporter->addResult($result);
+                $this->reportedKeys[$key] = true;
+            }
+        }
+
+        // Flush buffered results without completing the run.
+        // completeRun() is deferred to the shutdown function to prevent
+        // paratest's WrapperRunner from calling startRun/completeRun per
+        // test file, which causes StateManager count to prematurely reach
+        // zero and split results across multiple runs.
+        if (method_exists($this->reporter, 'sendResults')) {
+            $this->reporter->sendResults();
+        }
     }
 
     public function startTest(TestMethod $test): void
@@ -95,16 +126,10 @@ class QaseReporter implements QaseReporterInterface
 
         if (!isset($this->testResults[$key])) {
             $this->startTest($test);
-            $this->testResults[$key]->execution->setStatus($status);
-            $this->testResults[$key]->execution->finish();
-
-            $this->handleMessage($key, $message);
-            $this->reporter->addResult($this->testResults[$key]);
-            
-            return;
         }
 
         $this->testResults[$key]->execution->setStatus($status);
+        $this->testResults[$key]->execution->finish();
         $this->handleMessage($key, $message);
 
         if ($stackTrace) {
@@ -130,6 +155,7 @@ class QaseReporter implements QaseReporterInterface
         $this->testResults[$key]->execution->finish();
 
         $this->reporter->addResult($this->testResults[$key]);
+        $this->reportedKeys[$key] = true;
     }
 
     /**
@@ -175,7 +201,14 @@ class QaseReporter implements QaseReporterInterface
             }
         }
 
-        return Signature::generateSignature($ids, $finalSuites, $params);
+        $signature = Signature::generateSignature($ids, $finalSuites, $params);
+
+        $dataSetName = $this->getCurrentDataSetName($test);
+        if ($dataSetName !== null) {
+            $signature .= '::' . $dataSetName;
+        }
+
+        return $signature;
     }
 
     private function getThread(): string
@@ -252,7 +285,7 @@ class QaseReporter implements QaseReporterInterface
 
                 $hasOpaque = false;
                 foreach ($normalized as $value) {
-                    if ($value === '{}') {
+                    if ($value === self::OPAQUE_VALUE) {
                         $hasOpaque = true;
                         break;
                     }
@@ -261,7 +294,7 @@ class QaseReporter implements QaseReporterInterface
                 if ($hasOpaque) {
                     $fallback = (string) ($this->getCurrentDataSetName($test) ?? '0');
                     foreach ($normalized as $key => $value) {
-                        if ($value === '{}') {
+                        if ($value === self::OPAQUE_VALUE) {
                             $normalized[$key] = $fallback;
                         }
                     }
@@ -313,9 +346,8 @@ class QaseReporter implements QaseReporterInterface
     }
 
     /**
-     * Get data provider method name from test method attributes
-     */
-    /**
+     * Get data provider method names from test method attributes
+     *
      * @return string[]
      */
     private function getDataProviderMethodNames(TestMethod $test): array
@@ -354,7 +386,7 @@ class QaseReporter implements QaseReporterInterface
         $result = $method->invoke(null);
 
         if ($result instanceof \Traversable) {
-            $result = iterator_to_array($result);
+            $result = iterator_to_array($result, true);
         }
 
         return is_array($result) ? $result : null;

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -180,7 +180,12 @@ class QaseReporter implements QaseReporterInterface
 
     private function getThread(): string
     {
-        return $_ENV['TEST_TOKEN'] ?? "default";
+        $token = getenv("TEST_TOKEN");
+        if ($token !== false && $token !== "") {
+            return (string) $token;
+        }
+
+        return "default";
     }
 
     public function addComment(string $message): void


### PR DESCRIPTION
- missing params, if multiple data providers are used
- fallback for non-scalar parameter values
- fix thread ID for paratest
- fallback for generator data providers (using yield)
- fix for whitespace parameter value