### PR TITLE
fix: improve reporter stability for paratest and data providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "2.1.10",
+  "version": "2.1.11",
   "scripts": {
     "test": "phpunit"
   },

--- a/src/Events/TestPreparationErroredSubscriber.php
+++ b/src/Events/TestPreparationErroredSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qase\PHPUnitReporter\Events;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Test\PreparationErrored;
+use PHPUnit\Event\Test\PreparationErroredSubscriber;
+use Qase\PHPUnitReporter\QaseReporterInterface;
+
+final class TestPreparationErroredSubscriber implements PreparationErroredSubscriber
+{
+    private QaseReporterInterface $reporter;
+
+    public function __construct(
+        QaseReporterInterface $reporter
+    )
+    {
+        $this->reporter = $reporter;
+    }
+
+    public function notify(PreparationErrored $event): void
+    {
+        $test = $event->test();
+
+        if (!($test instanceof TestMethod)) {
+            return;
+        }
+
+        $throwable = $event->throwable();
+
+        $this->reporter->updateStatus($test, 'failed', $throwable->message(), $throwable->asString());
+    }
+}

--- a/src/QaseExtension.php
+++ b/src/QaseExtension.php
@@ -24,7 +24,7 @@ final class QaseExtension implements Extension
 
         $reporter = QaseReporter::getInstance($attributeParser, $coreReporter);
         
-        $facade->registerSubscribers(
+        $subscribers = [
             new Events\TestRunnerStartedSubscriber($reporter),
             new Events\TestPreparedSubscriber($reporter),
             new Events\TestPassedSubscriber($reporter),
@@ -36,6 +36,13 @@ final class QaseExtension implements Extension
             new Events\TestWarningTriggeredSubscriber($reporter),
             new Events\TestFinishedSubscriber($reporter),
             new Events\TestRunnerFinishedSubscriber($reporter),
-        );
+        ];
+
+        // PreparationErrored is available in PHPUnit 11.4+/12+
+        if (interface_exists(\PHPUnit\Event\Test\PreparationErroredSubscriber::class)) {
+            $subscribers[] = new Events\TestPreparationErroredSubscriber($reporter);
+        }
+
+        $facade->registerSubscribers(...$subscribers);
     }
 }

--- a/src/QaseExtension.php
+++ b/src/QaseExtension.php
@@ -25,18 +25,17 @@ final class QaseExtension implements Extension
         $reporter = QaseReporter::getInstance($attributeParser, $coreReporter);
         
         $facade->registerSubscribers(
-            new Events\TestConsideredRiskySubscriber($reporter),
+            new Events\TestRunnerStartedSubscriber($reporter),
             new Events\TestPreparedSubscriber($reporter),
-            new Events\TestFinishedSubscriber($reporter),
+            new Events\TestPassedSubscriber($reporter),
             new Events\TestFailedSubscriber($reporter),
             new Events\TestErroredSubscriber($reporter),
-            new Events\TestMarkedIncompleteSubscriber($reporter),
             new Events\TestSkippedSubscriber($reporter),
-            new Events\TestWarningTriggeredSubscriber($reporter),
+            new Events\TestMarkedIncompleteSubscriber($reporter),
             new Events\TestConsideredRiskySubscriber($reporter),
-            new Events\TestPassedSubscriber($reporter),
+            new Events\TestWarningTriggeredSubscriber($reporter),
+            new Events\TestFinishedSubscriber($reporter),
             new Events\TestRunnerFinishedSubscriber($reporter),
-            new Events\TestRunnerStartedSubscriber($reporter),
         );
     }
 }

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -21,6 +21,7 @@ class QaseReporter implements QaseReporterInterface
     private ReporterInterface $reporter;
     private ?string $currentKey = null;
     private bool $runStarted = false;
+    private array $reportedKeys = [];
 
     private function __construct(AttributeParserInterface $attributeParser, ReporterInterface $reporter)
     {
@@ -57,11 +58,25 @@ class QaseReporter implements QaseReporterInterface
 
     public function completeTestRun(): void
     {
-        // No-op: completeRun() is deferred to the shutdown function.
-        // This prevents paratest's WrapperRunner from calling
-        // startRun/completeRun per test file instead of per worker process,
-        // which causes StateManager count to fluctuate and prematurely
-        // complete the run.
+        // Report tests that never received a TestFinished event.
+        // In PHPUnit 12, tests that error during setUp() may not dispatch
+        // TestFinished, leaving results in $testResults but never sent.
+        // Their execution time was already stamped by updateStatus().
+        foreach ($this->testResults as $key => $result) {
+            if (!isset($this->reportedKeys[$key])) {
+                $this->reporter->addResult($result);
+                $this->reportedKeys[$key] = true;
+            }
+        }
+
+        // Flush buffered results without completing the run.
+        // completeRun() is deferred to the shutdown function to prevent
+        // paratest's WrapperRunner from calling startRun/completeRun per
+        // test file, which causes StateManager count to prematurely reach
+        // zero and split results across multiple runs.
+        if (method_exists($this->reporter, 'sendResults')) {
+            $this->reporter->sendResults();
+        }
     }
 
     public function startTest(TestMethod $test): void
@@ -114,6 +129,7 @@ class QaseReporter implements QaseReporterInterface
         }
 
         $this->testResults[$key]->execution->setStatus($status);
+        $this->testResults[$key]->execution->finish();
         $this->handleMessage($key, $message);
 
         if ($stackTrace) {
@@ -139,6 +155,7 @@ class QaseReporter implements QaseReporterInterface
         $this->testResults[$key]->execution->finish();
 
         $this->reporter->addResult($this->testResults[$key]);
+        $this->reportedKeys[$key] = true;
     }
 
     /**

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -20,6 +20,7 @@ class QaseReporter implements QaseReporterInterface
     private AttributeParserInterface $attributeParser;
     private ReporterInterface $reporter;
     private ?string $currentKey = null;
+    private bool $runStarted = false;
 
     private function __construct(AttributeParserInterface $attributeParser, ReporterInterface $reporter)
     {
@@ -42,12 +43,25 @@ class QaseReporter implements QaseReporterInterface
 
     public function startTestRun(): void
     {
+        if ($this->runStarted) {
+            return;
+        }
+
         $this->reporter->startRun();
+        $this->runStarted = true;
+
+        register_shutdown_function(function () {
+            $this->reporter->completeRun();
+        });
     }
 
     public function completeTestRun(): void
     {
-        $this->reporter->completeRun();
+        // No-op: completeRun() is deferred to the shutdown function.
+        // This prevents paratest's WrapperRunner from calling
+        // startRun/completeRun per test file instead of per worker process,
+        // which causes StateManager count to fluctuate and prematurely
+        // complete the run.
     }
 
     public function startTest(TestMethod $test): void
@@ -97,13 +111,6 @@ class QaseReporter implements QaseReporterInterface
 
         if (!isset($this->testResults[$key])) {
             $this->startTest($test);
-            $this->testResults[$key]->execution->setStatus($status);
-            $this->testResults[$key]->execution->finish();
-
-            $this->handleMessage($key, $message);
-            $this->reporter->addResult($this->testResults[$key]);
-            
-            return;
         }
 
         $this->testResults[$key]->execution->setStatus($status);
@@ -177,7 +184,14 @@ class QaseReporter implements QaseReporterInterface
             }
         }
 
-        return Signature::generateSignature($ids, $finalSuites, $params);
+        $signature = Signature::generateSignature($ids, $finalSuites, $params);
+
+        $dataSetName = $this->getCurrentDataSetName($test);
+        if ($dataSetName !== null) {
+            $signature .= '::' . $dataSetName;
+        }
+
+        return $signature;
     }
 
     private function getThread(): string

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -13,6 +13,8 @@ use Qase\PHPUnitReporter\Attributes\AttributeParserInterface;
 
 class QaseReporter implements QaseReporterInterface
 {
+    private const OPAQUE_VALUE = '{}';
+
     private static QaseReporter $instance;
     private array $testResults = [];
     private AttributeParserInterface $attributeParser;
@@ -180,7 +182,12 @@ class QaseReporter implements QaseReporterInterface
 
     private function getThread(): string
     {
-        return $_ENV['TEST_TOKEN'] ?? "default";
+        $token = getenv("TEST_TOKEN");
+        if ($token !== false && $token !== "") {
+            return (string) $token;
+        }
+
+        return "default";
     }
 
     public function addComment(string $message): void
@@ -243,7 +250,26 @@ class QaseReporter implements QaseReporterInterface
         try {
             $originalData = $this->getOriginalDataProviderData($test);
             if ($originalData !== null && is_array($originalData)) {
-                return $this->normalizeDataProviderData($originalData);
+                $normalized = $this->normalizeDataProviderData($originalData);
+
+                $hasOpaque = false;
+                foreach ($normalized as $value) {
+                    if ($value === self::OPAQUE_VALUE) {
+                        $hasOpaque = true;
+                        break;
+                    }
+                }
+
+                if ($hasOpaque) {
+                    $fallback = (string) ($this->getCurrentDataSetName($test) ?? '0');
+                    foreach ($normalized as $key => $value) {
+                        if ($value === self::OPAQUE_VALUE) {
+                            $normalized[$key] = $fallback;
+                        }
+                    }
+                }
+
+                return $normalized;
             }
             return [];
         } catch (\Throwable $e) {
@@ -261,45 +287,54 @@ class QaseReporter implements QaseReporterInterface
     private function getOriginalDataProviderData(TestMethod $test): ?array
     {
         try {
-            $dataProviderMethodName = $this->getDataProviderMethodName($test);
-            if ($dataProviderMethodName === null) {
+            $providerNames = $this->getDataProviderMethodNames($test);
+            if (empty($providerNames)) {
                 return null;
             }
-            
-            $allDataSets = $this->invokeDataProviderMethod($test->className(), $dataProviderMethodName);
-            if (!is_array($allDataSets)) {
-                return null;
-            }
-            
+
             $dataSetName = $this->getCurrentDataSetName($test);
             if ($dataSetName === null) {
                 return null;
             }
-            
-            return $this->findDataSet($allDataSets, $dataSetName);
+
+            foreach ($providerNames as $providerName) {
+                $allDataSets = $this->invokeDataProviderMethod($test->className(), $providerName);
+                if (!is_array($allDataSets)) {
+                    continue;
+                }
+                $found = $this->findDataSet($allDataSets, $dataSetName);
+                if ($found !== null) {
+                    return $found;
+                }
+            }
+
+            return null;
         } catch (\Throwable $e) {
             return null;
         }
     }
 
     /**
-     * Get data provider method name from test method attributes
+     * Get data provider method names from test method attributes
+     *
+     * @return string[]
      */
-    private function getDataProviderMethodName(TestMethod $test): ?string
+    private function getDataProviderMethodNames(TestMethod $test): array
     {
+        $names = [];
         $testReflection = new \ReflectionMethod($test->className(), $test->methodName());
-        
+
         foreach ($testReflection->getAttributes() as $attribute) {
             $attributeName = $attribute->getName();
             if (strpos($attributeName, 'DataProvider') !== false) {
                 $args = $attribute->getArguments();
                 if (!empty($args) && is_string($args[0])) {
-                    return $args[0];
+                    $names[] = $args[0];
                 }
             }
         }
-        
-        return null;
+
+        return $names;
     }
 
     /**
@@ -318,6 +353,11 @@ class QaseReporter implements QaseReporterInterface
         }
         
         $result = $method->invoke(null);
+
+        if ($result instanceof \Traversable) {
+            $result = iterator_to_array($result, true);
+        }
+
         return is_array($result) ? $result : null;
     }
 
@@ -482,7 +522,7 @@ class QaseReporter implements QaseReporterInterface
 
         if (is_scalar($value)) {
             $str = (string)$value;
-            return $str === '' ? 'empty' : $str;
+            return trim($str) === '' ? 'empty' : $str;
         }
 
         if (is_array($value)) {


### PR DESCRIPTION
## Summary
- Use `getenv()` instead of `$_ENV` for `TEST_TOKEN` (paratest compatibility)
- Support multiple `#[DataProvider]` attributes per test method
- Handle Generator (`yield`) data providers via `iterator_to_array()`
- Fallback to dataset name for non-serializable param values
- Sanitize whitespace-only param values to prevent API 422 rejections
- Extract `OPAQUE_VALUE` constant instead of magic string `'{}'`
- Bump version to 2.1.11

Based on PR #65, with additional improvements:
- Magic string `'{}'` replaced with `self::OPAQUE_VALUE` constant
- `iterator_to_array()` called with `preserve_keys: true` explicitly
- Cleaned up double PHPDoc block on `getDataProviderMethodNames()`

## Test plan
- [x] All 14 existing unit tests pass
- [ ] Verify paratest runs correctly pick up `TEST_TOKEN`
- [ ] Verify data providers with `yield` return correct params
- [ ] Verify multiple `#[DataProvider]` attributes resolve correctly
- [ ] Verify whitespace-only values don't cause 422 errors